### PR TITLE
+ Replaced `127.0.0.1`s with MEDIA_URL (backend small fix)

### DIFF
--- a/backend/events/views.py
+++ b/backend/events/views.py
@@ -4,11 +4,11 @@ Views for events
 from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.decorators import action
+from django.conf import settings
 from .models import Event
 from .serializers import EventSerializer
 
 
-from django.conf import settings
 
 class EventsViewSet(viewsets.ModelViewSet):
     """


### PR DESCRIPTION
## Context
- Events images on the backend point to 127.0.0.1/...
- This is fine when localhosting, but breaks when livehosting
- Attached is a non-working image upload to events on livehost

## Action
- Fixed by replacing with MEDIA_URL

![Image](https://github.com/user-attachments/assets/effcf762-f121-4c5d-b741-c4d31625b283)